### PR TITLE
clean up unused imports

### DIFF
--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1,9 +1,6 @@
 import itertools
 import unittest
 import math
-import os
-import shutil
-import tempfile
 
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1,6 +1,5 @@
 """ Unit tests for the problem interface."""
 
-import os
 import pathlib
 import sys
 import unittest

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -1,7 +1,6 @@
 """ Unit tests for the system interface."""
 
 import unittest
-import os
 
 import numpy as np
 

--- a/openmdao/error_checking/tests/test_check_config.py
+++ b/openmdao/error_checking/tests/test_check_config.py
@@ -1,8 +1,5 @@
-import errno
-import os
 import unittest
-from tempfile import mkdtemp, TemporaryFile
-from shutil import rmtree
+from tempfile import TemporaryFile
 
 import numpy as np
 

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -1,9 +1,6 @@
 """Tests the `debug_print` option for Nonlinear solvers."""
 
-import os
 import sys
-import shutil
-import tempfile
 
 import unittest
 from packaging.version import Version
@@ -32,8 +29,6 @@ nonlinear_solvers = [
 @use_tempdirs
 class TestNonlinearSolvers(unittest.TestCase):
     def setUp(self):
-        import os
-        from tempfile import mkdtemp
 
         # iteration coordinate, file name and variable data are common for all tests
         coord = 'rank0:root._solve_nonlinear|0|NLRunOnce|0|circuit._solve_nonlinear|0'

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -16,7 +16,6 @@ except ImportError:
     parameterized = None
 
 from openmdao.utils.general_utils import env_truthy, env_none
-from openmdao.utils.file_utils import get_work_dir
 
 
 def _new_setup(self):

--- a/openmdao/utils/tests/test_file_wrap.py
+++ b/openmdao/utils/tests/test_file_wrap.py
@@ -3,8 +3,6 @@ Testing the file wrapping utilities.
 """
 
 import os
-import tempfile
-import shutil
 
 import unittest
 


### PR DESCRIPTION
### Summary

clean up unused imports as [reported ](https://github.com/OpenMDAO/OpenMDAO/actions/runs/10617816142/job/29431573768?pr=3332) by `ruff`

```
Found 18 errors.
[*] 18 fixable with the `--fix` option.

[14:10:38](OM) swryan@Chimaera:~/dev/OpenMDAO$ pip install ruff
Collecting ruff
  Downloading ruff-0.6.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (25 kB)
Downloading ruff-0.6.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (10.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.3/10.3 MB 10.4 MB/s eta 0:00:00
Installing collected packages: ruff
Successfully installed ruff-0.6.3
[14:10:49](OM) swryan@Chimaera:~/dev/OpenMDAO$ ruff check --fix
Found 18 errors (18 fixed, 0 remaining).
[14:10:55](OM) swryan@Chimaera:~/dev/OpenMDAO$ 
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
